### PR TITLE
Added Gradle as a pre-req to build from source instructions.

### DIFF
--- a/docs/HowTo/Get-Started/Build-From-Source.md
+++ b/docs/HowTo/Get-Started/Build-From-Source.md
@@ -12,6 +12,7 @@ description: Build Teku from source
     Teku requires Java 11+; earlier versions are not supported.
 
 * [Git](https://git-scm.com/downloads) or [GitHub Desktop](https://desktop.github.com/)
+* [Gradle build tool](https://gradle.org/)
 
 ## Installation on Linux / Unix / MacOS X
 


### PR DESCRIPTION
Gradle was missing as a pre-requisite in the building from source instructions.  People getting started on a vm probably won't have gradle, so explicitly listing it is important.