### PR TITLE
Update the default network to medalla

### DIFF
--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -680,7 +680,7 @@ The default is `8008`.
     ```
 
 Predefined network configuration. Accepts a predefined network name, or file path or URL
-to a YAML configuration file. The default is `altona`.
+to a YAML configuration file. The default is `medalla`.
 
 Possible values are:
 


### PR DESCRIPTION
## Pull Request Description
Teku updated the default network to Medalla. This PR updates the CLI docs to reflect this.

## Fixed Issue(s)
fixes #148
