### PR TITLE
Change Site URL for Docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@
 
 # Project information
 site_name: Teku
-site_url: https://docs.teku.pegasys.tech/en/latest/
+site_url: https://docs.eth2signer.consensys.net/
 site_description: Teku Ethereum 2 client documentation.
 site_author: Teku community
 copyright: Teku and its documentation are licensed under Apache 2.0 license.


### PR DESCRIPTION
Changing Site URL to new https://docs.eth2signer.consensys.net/

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.common/wiki/Contributing-to-Pegasys-Documentation -->

## Pull Request Description
<!-- Please write a short description of your changes and any specific instructions to review them -->

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<github issue number> -->
<!-- Example: "fixes #42" -->
