### PR TITLE
fix site domain

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@
 
 # Project information
 site_name: Teku
-site_url: https://docs.eth2signer.consensys.net/
+site_url: https://docs.teku.consensys.net/
 site_description: Teku Ethereum 2 client documentation.
 site_author: Teku community
 copyright: Teku and its documentation are licensed under Apache 2.0 license.


### PR DESCRIPTION
fixes the domain name changed by #150 in the config file

## testing

Go to the [RTD preview](https://pegasys-teku--165.com.readthedocs.build/en/165), click the logo on the top left hand corner and it should go to teku site instead of web3signer (fka eth2signer)